### PR TITLE
Fix quiz refresh

### DIFF
--- a/src/components/lesson/QuizWidget.tsx
+++ b/src/components/lesson/QuizWidget.tsx
@@ -53,13 +53,11 @@ const QuizWidget: React.FC<QuizWidgetProps> = ({ quizData, onComplete }) => {
       setIsCorrect(correct);
       setQuestionSubmitted(true);
       
-      // Award XP for correct answer
+      // Award XP for correct answer without blocking UI
       if (correct) {
-        try {
-          await addExperience(50);
-        } catch (error) {
+        addExperience(50).catch(error => {
           console.error('Error awarding XP:', error);
-        }
+        });
       }
       
       // Show feedback with a small delay to ensure state is updated


### PR DESCRIPTION
## Summary
- update XP awarding so it runs asynchronously to avoid page refresh

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68601ec994848328a143e4aa3fb62028