### PR TITLE
Fix quiz refresh

### DIFF
--- a/src/components/lesson/QuizWidget.tsx
+++ b/src/components/lesson/QuizWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { LessonQuiz } from '../../types';
 import { CheckCircle, XCircle, Trophy } from 'lucide-react';
 import MathRenderer from '../common/MathRenderer';
@@ -53,14 +53,7 @@ const QuizWidget: React.FC<QuizWidgetProps> = ({ quizData, onComplete }) => {
       setIsCorrect(correct);
       setQuestionSubmitted(true);
       
-      // Award XP for correct answer
-      if (correct) {
-        try {
-          await addExperience(50);
-        } catch (error) {
-          console.error('Error awarding XP:', error);
-        }
-      }
+
       
       // Show feedback with a small delay to ensure state is updated
       setTimeout(() => {
@@ -72,7 +65,7 @@ const QuizWidget: React.FC<QuizWidgetProps> = ({ quizData, onComplete }) => {
     } finally {
       setIsSubmitting(false);
     }
-  }, [questionSubmitted, showFeedback, isSubmitting, selectedAnswers, currentQuestion, quizData, addExperience]);
+  }, [questionSubmitted, showFeedback, isSubmitting, selectedAnswers, currentQuestion, quizData]);
 
   const handleNext = useCallback((e?: React.MouseEvent) => {
     // Prevent default behavior and stop propagation
@@ -118,6 +111,15 @@ const QuizWidget: React.FC<QuizWidgetProps> = ({ quizData, onComplete }) => {
     setQuestionSubmitted(false);
     setIsSubmitting(false);
   }, [quizData.length]);
+
+  // Award XP after submitting a correct answer
+  useEffect(() => {
+    if (questionSubmitted && isCorrect) {
+      addExperience(50).catch(error => {
+        console.error('Error awarding XP:', error);
+      });
+    }
+  }, [questionSubmitted, isCorrect, addExperience]);
 
   // Function to render text with math expressions
   const renderTextWithMath = (text: string) => {


### PR DESCRIPTION
## Summary
- update QuizWidget so XP is added in a side-effect after submission

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68601ec994848328a143e4aa3fb62028