### PR TITLE
Update branding to EduVibe

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EduAI - Platformă Educațională AI pentru Elevi</title>
+    <title>EduVibe – Platformă Educațională AI pentru Elevi</title>
+    <meta name="description" content="EduVibe – Platformă Educațională AI pentru Elevi" />
     
     <!-- MathJax Configuration -->
     <script>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -27,7 +27,7 @@ const Navbar: React.FC = () => {
         <div className="flex justify-between h-16">
           <div className="flex items-center">
             <Link to="/dashboard" className="flex items-center flex-shrink-0">
-              <span className="text-xl font-bold text-white">EduAI</span>
+              <span className="text-xl font-bold text-white">EduVibe</span>
             </Link>
           </div>
 

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -122,7 +122,7 @@ const OnboardingPage: React.FC = () => {
             <Lightbulb className="h-10 w-10 text-indigo-600" />
           </div>
           <h1 className="text-2xl font-bold text-gray-900">
-            {step === 1 && 'Bun venit la EduAI'}
+            {step === 1 && 'Bun venit la EduVibe'}
             {step === 2 && 'Alege tipul de examen'}
             {step === 3 && 'Alege materiile de interes'}
             {step === 4 && 'Evaluare inițială'}

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -21,7 +21,7 @@ const RegisterPage: React.FC = () => {
           <Lightbulb className="h-10 w-10 text-indigo-600" />
         </div>
         <h1 className="text-3xl font-bold text-gray-900">
-          EduAI
+          EduVibe
         </h1>
         <p className="mt-2 text-gray-600">
           Creează-ți contul și începe să înveți inteligent


### PR DESCRIPTION
## Summary
- update HTML title and meta description to use EduVibe branding
- change navbar, register, and onboarding text from EduAI to EduVibe

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b039c9661c8328a9d16d5b22f41b05